### PR TITLE
Switch to org.gnome.Platform runtime

### DIFF
--- a/org.eclipse.Java.json
+++ b/org.eclipse.Java.json
@@ -1,6 +1,6 @@
 {
   "id" : "org.eclipse.Java",
-  "runtime" : "org.gnome.Sdk",
+  "runtime" : "org.gnome.Platform",
   "runtime-version" : "3.38",
   "sdk" : "org.gnome.Sdk",
   "sdk-extensions" : [


### PR DESCRIPTION
We used to need org.gnome.SDK in the past when eclipse ecosystem was not prepared. It should be fine with 2020-09 release we ship now.