### PR TITLE
Added StartupWMClass

### DIFF
--- a/org.eclipse.Java.desktop
+++ b/org.eclipse.Java.desktop
@@ -7,3 +7,4 @@ Exec=eclipse %f
 Terminal=false
 Categories=Development;IDE;
 MimeType=text/x-java;text/x-maven+xml;text/x-gradle;text/x-patch;text/x-diff;
+StartupWMClass=Eclipse


### PR DESCRIPTION
When Eclipse starts, the window isn't associated with the .desktop launcher. This fixes that.