### PR TITLE
Revert "Added StartupWMClass"

### DIFF
--- a/org.eclipse.Java.desktop
+++ b/org.eclipse.Java.desktop
@@ -7,4 +7,3 @@ Exec=eclipse %f
 Terminal=false
 Categories=Development;IDE;
 MimeType=text/x-java;text/x-maven+xml;text/x-gradle;text/x-patch;text/x-diff;
-StartupWMClass=Eclipse


### PR DESCRIPTION
Reverts flathub/org.eclipse.Java#22
This makes zip download from eclipse.org and the flatpak being considered the same and if you start one of them the other one can't be started but rather the already running one is bringed to top. Thus has to revert it.