### PR TITLE
Running all JUnit tests in a project fails for Flatpak Eclipse #42

### DIFF
--- a/org.eclipse.Java.json
+++ b/org.eclipse.Java.json
@@ -8,6 +8,7 @@
   "finish-args" : [
     "--require-version=1.7.1",
     "--filesystem=host",
+    "--filesystem=/tmp:rw",
     "--share=network",
     "--share=ipc",
     "--socket=x11",


### PR DESCRIPTION
Fix enables the access to `/tmp` directory

Issue #42
Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>