### PR TITLE
Add xdg-run/gvfsd privilege

### DIFF
--- a/org.eclipse.Java.json
+++ b/org.eclipse.Java.json
@@ -8,6 +8,7 @@
   "finish-args" : [
     "--require-version=1.7.1",
     "--filesystem=host",
+    "--filesystem=xdg-run/gvfsd",
     "--share=network",
     "--share=ipc",
     "--socket=x11",


### PR DESCRIPTION
When openning a file/directory selection dialog an error message appears in console:

(Eclipse:24): GVFS-WARNING **: 15:32:13.901: The peer-to-peer connection failed: Error when getting information for file “/run/user/1000/gvfsd”: No such file or directory.
Falling back to the session bus. Your application is probably missing --filesystem=xdg-run/gvfsd privileges.

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>