### PR TITLE
[RPM] rpmdevtools not found #38

### DIFF
--- a/org.eclipse.Java.json
+++ b/org.eclipse.Java.json
@@ -14,8 +14,10 @@
     "--socket=x11",
     "--socket=wayland",
     "--allow=devel",
+    "--talk-name=org.freedesktop.Flatpak",
     "--socket=session-bus",
-    "--device=dri"
+    "--device=dri",
+    "--env=PATH=/app/bin:/usr/bin"
   ],
   "modules" : [ {
     "name" : "eclipse",


### PR DESCRIPTION
Talk permission graned: "--talk-name=org.freedesktop.Flatpak"
Sandbox's representation of host's `/usr/bin` (`/var/run/host/usr/bin`) is added to the system path

Issue: #38

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>