### PR TITLE
Added no-debuginfo build option

### DIFF
--- a/org.eclipse.Java.json
+++ b/org.eclipse.Java.json
@@ -21,6 +21,9 @@
         {
             "name": "eclipse",
             "buildsystem": "simple",
+            "build-options": {
+                  "no-debuginfo": true
+            },
             "build-commands": [
                 "mv eclipse /app",
                 "mkdir -p /app/bin",
@@ -45,8 +48,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.eclipse.org/technology/epp/downloads/release/2023-06/R/eclipse-java-2023-06-R-linux-gtk-x86_64.tar.gz",
-                    "sha512": "7683dd8c9934ca668c16068174ecf1f591fecb9b75866c58288b705884f78939ccfb4143c5cd435d02679b6cf6442fac96255702786fec64a605010fe0a0fbb5",
+                    "url": "https://download.eclipse.org/technology/epp/downloads/release/2023-09/R/eclipse-java-2023-09-R-linux-gtk-x86_64.tar.gz",
+                    "sha512": "eb2c72dbc545d3e828430c359e6c76ca9f4184095504bec7b0ce675fffea74cb558aa307227fb533993f703fbcafaab6ca2daec3200a0987a96ca9cf8dbcee01",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "html",


### PR DESCRIPTION
With this flag, I managed to run flatpak-builder with success.