### PR TITLE
Include GdkPixbuf with legacy BMP support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .flatpak-builder/
 /build-dir/
+/repo/

--- a/org.eclipse.Java.json
+++ b/org.eclipse.Java.json
@@ -20,6 +20,27 @@
     ],
     "modules": [
         {
+            "name": "gdk-pixbuf",
+            "buildsystem": "meson",
+            "config-opts": [
+            "-Dothers=enabled",
+            "-Dman=false",
+            "-Dgtk_doc=false",
+            "-Dbuiltin_loaders=png,bmp,gif"
+            ],
+            "sources": [
+            {
+                "type": "git",
+                "url": "https://gitlab.gnome.org/GNOME/gdk-pixbuf.git",
+                "tag": "2.42.12",
+                "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^([\\d.]+)$"
+                }
+            }
+            ]
+        },
+        {
             "name": "eclipse",
             "buildsystem": "simple",
             "build-options": {


### PR DESCRIPTION
Closes https://github.com/flathub/org.eclipse.Java/issues/105