### PR TITLE
Remove git data checker for GNOME

### DIFF
--- a/org.eclipse.Java.json
+++ b/org.eclipse.Java.json
@@ -32,11 +32,7 @@
             {
                 "type": "git",
                 "url": "https://gitlab.gnome.org/GNOME/gdk-pixbuf.git",
-                "tag": "2.42.12",
-                "x-checker-data": {
-                "type": "git",
-                "tag-pattern": "^([\\d.]+)$"
-                }
+                "tag": "2.42.12"
             }
             ]
         },


### PR DESCRIPTION
https://github.com/flathub/org.eclipse.Java/pull/107 is not helpful.