### PR TITLE
Fix wrong version and missing changelog for release 2026-06

### DIFF
--- a/org.eclipse.Java.metainfo.xml
+++ b/org.eclipse.Java.metainfo.xml
@@ -33,6 +33,9 @@
   </developer>
   <update_contact>akurtakov@gmail.com</update_contact>
   <releases>
+    <release version="4.40" date="2026-06-01">
+      <url>https://www.eclipse.org/eclipse/news/4.40/</url>
+    </release>
     <release version="4.39" date="2026-03-11">
       <url>https://www.eclipse.org/eclipse/news/4.39/</url>
     </release>


### PR DESCRIPTION
This was forgotten in https://github.com/flathub/org.eclipse.Java/pull/135.